### PR TITLE
change package-source to package_source for consistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Attributes
     <td><tt>nil</tt></td>
   </tr>
   <tr>
-    <td><tt>['chef-analytics']['package-source']</tt></td>
+    <td><tt>['chef-analytics']['package_source']</tt></td>
     <td>String</td>
     <td>Anything other than package cloud</td>
     <td><tt>nil</tt></td>

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -18,7 +18,7 @@
 #
 #
 default['chef-analytics']['version'] = nil
-default['chef-analytics']['package-source'] = nil
+default['chef-analytics']['package_source'] = nil
 
 # The Chef Analytics Server must have an API FQDN set.
 # https://docs.chef.io/install_analytics.html


### PR DESCRIPTION
Chef_ingredient used package_source as well as chef-analytics/recipe/default.rb.  Changing this to be consistent
