### PR TITLE
adds accept_license attribute

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -9,7 +9,9 @@ provisioner:
 
 platforms:
   - name: ubuntu-12.04
+  - name: ubuntu-14.04
   - name: centos-6.7
+  - name: centos-7.2
 
 suites:
   - name: default
@@ -17,4 +19,5 @@ suites:
       - recipe[chef-analytics]
     attributes:
       chef-analytics:
+        accept_license: true
         fqdn: 'analytics.chef.piab'

--- a/README.md
+++ b/README.md
@@ -63,6 +63,12 @@ Attributes
     <td>Arbitrary config to add to opscode-analytics.rb</td>
     <td><tt>{}</tt></td>
   </tr>
+  <tr>
+    <td><tt>['chef-analytics']['accept_license']</tt></td>
+    <td>Boolean</td>
+    <td>Boolean value indicating you agree to the [Chef MLSA](https://www.chef.io/online-master-agreement/)</td>
+    <td><tt>false</tt></td>
+  </tr>
 </table>
 
 Usage

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -25,8 +25,12 @@ default['chef-analytics']['channel'] = :stable
 # https://docs.chef.io/install_analytics.html
 default['chef-analytics']['api_fqdn'] = node['fqdn']
 
+# Chef requires agreement to the MLSA
+# https://www.chef.io/online-master-agreement/
+default['chef-analytics']['accept_license'] = false
+
 #
-# Chef Server Tunables
+# Chef Analytics Tunables
 #
 # For a complete list see:
 # https://docs.chef.io/config_rb_analytics.html

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -18,6 +18,7 @@ chef_ingredient 'analytics' do
   channel node['chef-analytics']['channel'].to_sym
   version node['chef-analytics']['version']
   package_source node['chef-analytics']['package_source']
+  accept_license node['chef-analytics']['accept_license'] unless node['chef-analytics']['accept_license'].nil?
   action :upgrade
 end
 


### PR DESCRIPTION
### Description

Adds the `accept_license` attribute with default value set to `false`. 

It's all @mengesb work out of https://github.com/chef-cookbooks/chef-analytics/pull/6 that only pertains to accept_license. I removed the changes to libraries/helper.rb from this commit.
### Issues Resolved

Issue #5 
### Check List
- [x] All tests pass. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] The CLA has been signed. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD

fixes #5
